### PR TITLE
fix Public Client And Confidential Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ function signInClicked() {
 
   const url = new URL("https://auth.byndid.com/v2/authorize");
   url.searchParams.append("client_id", "<CLIENT_ID>");
-  url.searchParams.append("redirect_url", "<REDIRECT_URI>");
+  url.searchParams.append("redirect_uri", "<REDIRECT_URI>");
   url.searchParams.append("state", state);
   url.searchParams.append("response_type", "code");
   url.searchParams.append("scope", "openid");


### PR DESCRIPTION
There was a typo in the Public Client And Confidential Client code example.. redirect_uri vs redirect_url